### PR TITLE
Enable metric relabelings for syseleven-exporter.

### DIFF
--- a/charts/syseleven-exporter-chart/templates/servicemonitor.yaml
+++ b/charts/syseleven-exporter-chart/templates/servicemonitor.yaml
@@ -14,15 +14,15 @@ spec:
     matchLabels:
       {{- include "syseleven-exporter.selectorLabels" . | nindent 6 }}
   {{- with .Values.prometheus.serviceMonitor.jobLabel }}
-  jobLabel: {{ . | quote}}
+  jobLabel: {{ . | quote }}
   {{- end }}
   {{- with .Values.prometheus.serviceMonitor.targetLabels }}
   targetLabels:
-{{ toYaml . | trim | indent 4 -}}
+    {{ toYaml . | trim | indent 4 -}}
   {{- end }}
   {{- with .Values.prometheus.serviceMonitor.podTargetLabels }}
   podTargetLabels:
-{{ toYaml . | trim | indent 4 -}}
+    {{ toYaml . | trim | indent 4 -}}
   {{- end }}
   endpoints:
     - path: /metrics
@@ -34,7 +34,12 @@ spec:
       scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
   {{- end }}
   {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
-      metricRelabelings: {{ toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 8 }}
+      metricRelabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 8 }}
+  {{- end }}
+  {{- if .Values.prometheus.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 8 }}
   {{- end }}
   namespaceSelector:
     matchNames:

--- a/charts/syseleven-exporter-chart/values.yaml
+++ b/charts/syseleven-exporter-chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: staffbace/syseleven-exporter
   pullPolicy: IfNotPresent
   tag:
-  
+
 service:
   labels: {}
   annotations: {}
@@ -26,7 +26,20 @@ prometheus:
     jobLabel: ""
     targetLabels: []
     podTargetLabels: []
+    # MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+    # RelabelConfigs to apply to samples before scraping.
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name, bla]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
   rules:
     enabled: false
     namespace:
@@ -43,7 +56,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-nodeSelector: 
+nodeSelector:
 
 tolerations: []
 


### PR DESCRIPTION
Add missing reLabeling configuration to k8s resource kind: ServiceMonitor