### PR TITLE
add dropdown template variable for prometheus datasources

### DIFF
--- a/charts/syseleven-exporter-chart/dashboards/syseleven-exporter-quotas.json
+++ b/charts/syseleven-exporter-chart/dashboards/syseleven-exporter-quotas.json
@@ -18,7 +18,10 @@
     "links": [],
     "panels": [{
             "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -28,7 +31,10 @@
             "id": 9,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -88,7 +94,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "CPUs"
@@ -182,7 +191,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "CPUs"
@@ -277,7 +289,10 @@
         },
         {
             "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -287,7 +302,10 @@
             "id": 19,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -347,7 +365,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "decmbytes"
@@ -441,7 +462,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "decmbytes"
@@ -536,7 +560,10 @@
         },
         {
             "collapsed": false,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -550,7 +577,10 @@
         },
         {
             "cacheTimeout": null,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "fieldConfig": {
                 "defaults": {
                     "color": {
@@ -610,7 +640,10 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "fieldConfig": {
                 "defaults": {
                     "unit": "bytes"
@@ -704,7 +737,10 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "fieldConfig": {
                 "defaults": {
                     "unit": "bytes"
@@ -795,7 +831,10 @@
         },
         {
             "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -805,7 +844,10 @@
             "id": 39,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -865,7 +907,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "bytes"
@@ -959,7 +1004,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "bytes"
@@ -1054,7 +1102,10 @@
         },
         {
             "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -1064,7 +1115,10 @@
             "id": 44,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -1124,7 +1178,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "none"
@@ -1218,7 +1275,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "none"
@@ -1313,7 +1373,10 @@
         },
         {
             "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -1323,7 +1386,10 @@
             "id": 14,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -1383,7 +1449,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "Instances"
@@ -1477,7 +1546,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+              },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "Instances"
@@ -1571,8 +1643,10 @@
             "type": "row"
         },
         {
-            "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -1582,7 +1656,10 @@
             "id": 34,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -1642,7 +1719,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "none"
@@ -1736,7 +1816,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "none"
@@ -1831,7 +1914,10 @@
         },
         {
             "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -1841,7 +1927,10 @@
             "id": 29,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -1901,7 +1990,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "IPs"
@@ -1995,7 +2087,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "IPs"
@@ -2090,7 +2185,10 @@
         },
         {
             "collapsed": true,
-            "datasource": null,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
             "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -2100,7 +2198,10 @@
             "id": 24,
             "panels": [{
                     "cacheTimeout": null,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "color": {
@@ -2160,7 +2261,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "Zones"
@@ -2254,7 +2358,10 @@
                     "bars": false,
                     "dashLength": 10,
                     "dashes": false,
-                    "datasource": null,
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${datasource}"
+                    },
                     "fieldConfig": {
                         "defaults": {
                             "unit": "Zones"
@@ -2352,7 +2459,22 @@
     "style": "dark",
     "tags": [],
     "templating": {
-        "list": []
+        "list": [
+          {
+            "current": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Data Source",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
     },
     "time": {
         "from": "now-6h",
@@ -2362,5 +2484,5 @@
     "timezone": "",
     "title": "SysEleven - Quotas",
     "uid": "ezkVYBqMz",
-    "version": 3
+    "version": 4
 }


### PR DESCRIPTION
actually, the datasource for the dashboard is not defined. When using multiple prometheus datasources in grafana, it is not possible to choose the datasource needed for all the panels in an easy way.

With this PR, there is a dropdown in the dashboard which defines the datasource for all the panels.