### PR TITLE
Add possibility to use existing secret for openstack config

### DIFF
--- a/charts/syseleven-exporter-chart/Chart.yaml
+++ b/charts/syseleven-exporter-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/syseleven-exporter-chart/templates/_helpers.tpl
+++ b/charts/syseleven-exporter-chart/templates/_helpers.tpl
@@ -54,5 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Secret name for Openstack Credentials
 */}}
 {{- define "syseleven-exporter.secret" -}}
-    {{ template "syseleven-exporter.fullname" . }}
-{{- end -}}
+{{- if .Values.openstack.existingSecret -}}
+{{- .Values.openstack.existingSecret }}
+{{- else }}
+{{- template "syseleven-exporter.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/syseleven-exporter-chart/templates/secret.yaml
+++ b/charts/syseleven-exporter-chart/templates/secret.yaml
@@ -1,4 +1,4 @@
-  
+{{ if not .Values.openstack.existingSecret}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +10,4 @@ stringData:
   OS_USERNAME: {{ .Values.openstack.username }}
   OS_PASSWORD: {{ .Values.openstack.password }}
   OS_PROJECT_ID: {{ .Values.openstack.projectId }}
+{{- end }}

--- a/charts/syseleven-exporter-chart/values.yaml
+++ b/charts/syseleven-exporter-chart/values.yaml
@@ -74,3 +74,6 @@ openstack:
   projectId: ""
   username: ""
   password: ""
+  # When existingSecret is set this chart will ignore the individual openstack values and use these provided in the secret
+  # The secret will need to include the three keys OS_USERNAME,OS_PASSWORD,OS_PROJECT_ID 
+  existingSecret: ""


### PR DESCRIPTION
To be able to use this chart securely with gitOps tooling the ability to use existing secrets that are created via gitOps and encrypted in the repositories to not expose secret information is crucial. 
We'd like to introduce this feature to this helm chart. 
The external Secret config would be optional and should not introduce changes for users of the chart that use the current configuration possibilities